### PR TITLE
Add unit test for getBaseExec

### DIFF
--- a/tests/parser_test.nim
+++ b/tests/parser_test.nim
@@ -1,0 +1,10 @@
+import unittest
+import ../src/parser
+
+suite "getBaseExec":
+  test "extract kitty binary":
+    check getBaseExec("/usr/bin/kitty --single-instance") == "kitty"
+
+  test "extract code binary":
+    check getBaseExec("code %F") == "code"
+


### PR DESCRIPTION
## Summary
- add `parser_test.nim` to test `getBaseExec`

## Testing
- `nimble test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ea5648fc8328bf848deea2970fdb