### PR TITLE
Optimize ranking to keep only top visible items

### DIFF
--- a/src/nlauncher.nim
+++ b/src/nlauncher.nim
@@ -3,7 +3,7 @@
 
 # ── Imports ─────────────────────────────────────────────────────────────
 import std/[os, osproc, strutils, options, tables, sequtils, json, uri, sets,
-    algorithm, times]
+    algorithm, times, heapqueue]
 import parsetoml as toml
 import x11/[xlib, x, xutil, keysym]
 import ./[state, parser, gui, utils]
@@ -464,12 +464,18 @@ proc buildActions() =
         if not seen.contains(app.name):
           actions.add Action(kind: akApp, label: app.name, exec: app.exec, appData: app)
     else:
-      var ranked: seq[(int, Action)] = @[]
+      var top = initHeapQueue[(int, Action)]()
+      let limit = config.maxVisibleItems
       for app in allApps:
         let s = scoreMatch(inputText, app.name, app.name, "")
         if s > -1_000_000:
-          ranked.add (s + recentBoost(app.name),
-                      Action(kind: akApp, label: app.name, exec: app.exec, appData: app))
+          push(top, (s + recentBoost(app.name),
+                     Action(kind: akApp, label: app.name, exec: app.exec, appData: app)))
+          if top.len > limit:
+            discard pop(top)
+      var ranked: seq[(int, Action)] = @[]
+      while top.len > 0:
+        ranked.add pop(top)
       ranked.sort(proc(a, b: (int, Action)): int =
         result = cmp(b[0], a[0])
         if result == 0: result = cmpIgnoreCase(a[1].label, b[1].label)


### PR DESCRIPTION
## Summary
- Limit ranked app results using a heap to retain only the top `maxVisibleItems`
- Import `heapqueue` for efficient partial sorting

## Testing
- `nimble build -y` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689749db806883289d385b3823a845de