### PR TITLE
Use t: to preview themes and add typo-tolerant fuzzy search

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 | **Recent-apps history**              | Empty query shows your last launches first                                                                        |
 | **100% keyboard-driven**             | Arrow keys / PageUp / PageDown / Home / End / Left / Right / Enter / Esc                                          |
 | **Live theme cycling & persistence** | Press F5 to cycle themes; saves your last choice in the TOML config                                               |
-| **Theme preview mode**               | `/t` shows a lightweight preview list of available themes                                                         |
+| **Theme preview mode**               | `t:` shows a lightweight preview list of available themes                                                         |
 | **Fully themable via TOML**          | 25+ colour schemes built-in; add your own under `[[themes]]` in `nlauncher.toml`                                  |
-| **Prefix triggers**                   | `/ …` run shell command • `c: …` open dotfile • `y: …` YouTube • `g: …` Google • `w: …` Wiki • `/t` Theme preview |
+| **Prefix triggers**                   | `/ …` run shell command • `c: …` open dotfile • `y: …` YouTube • `g: …` Google • `w: …` Wiki • `t:` Theme preview |
 | **Zero toolkit**                     | Pure Xlib + Xft + [parsetoml](https://github.com/pragmagic/parsetoml)                                             |
 
 ---
@@ -67,7 +67,7 @@ nimble release   # produces ./bin/nlauncher
 | `y: …`                | Search YouTube in browser                                              |
 | `g: …`                | Google search in browser                                               |
 | `w: …`                | Wikipedia search in browser                                            |
-| `/t`                  | Preview available themes in a quick selection list                     |
+| `t:`                  | Preview available themes in a quick selection list                     |
 | **Enter**             | Launch item / run command                                              |
 | **Esc**               | Quit                                                                   |
 | **↑ / ↓**             | Navigate list                                                          |

--- a/src/state.nim
+++ b/src/state.nim
@@ -57,7 +57,7 @@ type
     akYouTube, # `y:` YouTube search
     akGoogle,  # `g:` Google search
     akWiki,     # `w:` Wiki search
-    akTheme    # `/t` Theme selector
+    akTheme    # `t:` Theme selector
 
   ## A single selectable entry in the launcher.
   Action* = object
@@ -143,7 +143,7 @@ width = 2                         # Border thickness in pixels (0 = no border)
 # Themes
 # ==========================
 # Add or remove [[themes]] blocks to customize appearance.
-# The "name" field is what you'll see in the theme selector (/t or F5).
+# The "name" field is what you'll see in the theme selector (t: or F5).
 # Colors:
 #   bgColorHex          = Window background
 #   fgColorHex          = Normal text color
@@ -152,7 +152,7 @@ width = 2                         # Border thickness in pixels (0 = no border)
 #   borderColorHex      = Window border color
 #   matchFgColorHex     = Color for matching characters in search results
 #
-# Tip: You can quickly preview themes in-app with the `/t` command.
+# Tip: You can quickly preview themes in-app with the `t:` command.
 
 [[themes]]
 name                = "Arstotzka"   


### PR DESCRIPTION
## Summary
- Trigger theme selection with `t:` instead of `/t`
- Apply Levenshtein-based fuzzy scoring for theme and `c:` config searches
- Document new theme prefix

## Testing
- `nimpretty src/nlauncher.nim` *(fails: command not found)*
- `nim c src/nlauncher.nim` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6897600bd2c4832891a2c67d411c1e07